### PR TITLE
修复了乱码和检票时重复调用render()函数

### DIFF
--- a/static/a/activity/checkin/index.html
+++ b/static/a/activity/checkin/index.html
@@ -4,6 +4,7 @@
     <title>检票 - 紫荆之声</title>
     <link rel="stylesheet" href="/3rd/bs/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="/css/activity_checkin.css"/>
+    <meta charset="UTF-8">
 </head>
 <body onload="auto_adjust();" onresize="auto_adjust();">
 
@@ -125,7 +126,6 @@
     };
     $(function () {
         swig.setDefaultTZOffset(new Date().getTimezoneOffset());
-        render();
         loginRequired(function () {
             api.get('/api/a/activity/detail', {id: urlParam.id}, function (data) {
                 locals.activity = data;


### PR DESCRIPTION
在未添加<meta charset="UTF-8">前，可能会出现乱码（之所以用可能是因为在我和同伴的机器上表现不一致）。
在未删除render()前，每次检票会导致重复提交。