### PR TITLE
bug fix: missing query string on redirection to /a/login

### DIFF
--- a/static/js/base_admin.js
+++ b/static/js/base_admin.js
@@ -1,7 +1,11 @@
+window.location.pathname_with_query_string = function(){
+    return this.href.substring(this.origin.length);
+}
+
 window.loginRequired = function (cb) {
     api.get('/api/a/login', {}, cb, function () {
         window.location.href = '/a/login?' + $.param({
-            next: window.location.pathname
+            next: window.location.pathname_with_query_string()
         });
     });
 };
@@ -9,7 +13,7 @@ window.loginRequired = function (cb) {
 window.logout = function () {
     api.post('/api/a/logout', {}, null, dftFail, function () {
         window.location.href = '/a/login?' + $.param({
-            next: window.location.pathname
+            next: window.location.pathname_with_query_string()
         });
     });
 };


### PR DESCRIPTION
复现步骤：
0. 浏览器登录管理后台，打开任意活动的详情页
1. 点击右上角“登出”
2. 输入用户名密码，点击“登录”
3. 此时缺少 id 字段而报错

    /a/activity/detail?id=1
    /a/login?next=%2Fa%2Factivity%2Fdetail
    /a/login?next=%2Fa%2Factivity%2Fdetail%3Fid%3D1