### PR TITLE
bug fix: wrong Content-Type uploading file

### DIFF
--- a/static/js/base_admin.js
+++ b/static/js/base_admin.js
@@ -44,6 +44,7 @@ window.api.postForm = function (url, data, success, fail, complete) {
         type: 'POST',
         url: url,
         data: data,
+        contentType: false,
         processData: false
     }).done(function (response, status, xhr) {
         if (response.code != 0) {


### PR DESCRIPTION
上传文件时 `Content-Type` 标头的值应为 `multipart/form-data`，而非默认的 `application/x-www-form-urlencoded`。

顺便指出，在后端，应由 `self.request.FILES['image']` 得到上传的文件，而非文档暗示的 `self.input['image']`。

references:
* https://docs.djangoproject.com/en/1.10/topics/http/file-uploads/
* http://api.jquery.com/jquery.ajax/