### PR TITLE
change the api.post "data" param from array to dict in menu/index page

### DIFF
--- a/static/a/activity/menu/index.html
+++ b/static/a/activity/menu/index.html
@@ -189,7 +189,7 @@
         });
         locals.status = 1;
         render();
-        api.post('/api/a/activity/menu', ids, function (data) {
+        api.post('/api/a/activity/menu', {'ids':ids}, function (data) {
             locals.status = 2;
             render();
         }, function (errno, errmsg, e) {


### PR DESCRIPTION
According to the development document, the function api.post has parameter "data" in dictionary format .

But in the static/a/activity/menu/index/html, the api.post receives "data" in array format. 

As a result, we would get wrong if we directly use check_input method in django view.
